### PR TITLE
small fixes

### DIFF
--- a/example/lib/room_client.dart
+++ b/example/lib/room_client.dart
@@ -25,7 +25,7 @@ class RoomClient {
   Map<String, DataConsumer> _dataConsumers = {};
   Map<String, MediaDeviceInfo> _webcams = {};
   bool _produce = false;
-  bool _consume = false;
+  bool _consume = true;
 
   RoomClient({
     this.roomId,
@@ -351,7 +351,7 @@ class RoomClient {
       switch (request['method']) {
         case 'newConsumer':
           {
-            if (!_consume) {
+            if (!_consume || request['data']['kind'] == 'audio') {
               reject(403, 'I do not want to consume');
               break;
             }
@@ -363,7 +363,10 @@ class RoomClient {
                     request['data']['kind']),
                 rtpParameters:
                     RtpParameters.fromMap(request['data']['rtpParameters']),
-                appData: Map<dynamic, dynamic>.from(request['data']['appData']),
+                appData: Map<dynamic, dynamic>.from({
+                  ...request['data']['appData'],
+                  peerId: request['data']['peerId']
+                }),
               );
             } catch (error) {
               print('newConsumer request failed: $error');

--- a/lib/src/Device.dart
+++ b/lib/src/Device.dart
@@ -262,16 +262,8 @@ class Device {
       dtlsParameters: DtlsParameters.fromMap(data['dtlsParameters']),
       sctpParameters: SctpParameters.fromMap(data['sctpParameters']),
       iceServers: [],
-      proprietaryConstraints: Map<String, dynamic>.from({
-        'optional': [
-          {
-            'googDscp': true,
-          }
-        ]
-      }),
-      additionalSettings: {
-        'encodedInsertableStreams': false,
-      },
+      proprietaryConstraints:Map<String, dynamic>(),
+      additionalSettings: Map<String, dynamic>(),
       producerCallback: producerCallback,
       dataProducerCallback: dataProducerCallback,
     );
@@ -329,16 +321,8 @@ class Device {
       sctpParameters: data['sctpParameters'] != null ? SctpParameters.fromMap(data['sctpParameters']) : null,
       iceServers: [],
       appData: data['appData'] ?? {},
-      proprietaryConstraints: Map<String, dynamic>.from({
-        'optional': [
-          {
-            'googDscp': true,
-          }
-        ]
-      }),
-      additionalSettings: {
-        'encodedInsertableStreams': false,
-      },
+      proprietaryConstraints: Map<String, dynamic>(),
+      additionalSettings: Map<String, dynamic>(),
       consumerCallback: consumerCallback,
       dataConsumerCallback: dataConsumerCallback,
     );

--- a/lib/src/Transport.dart
+++ b/lib/src/Transport.dart
@@ -932,7 +932,7 @@ class Transport extends EnhancedEventEmitter {
     }
 
     _flexQueue.addTask(FlexTaskAdd(
-        id: id,
+        id: '',
         message: 'transport.consume()',
         execFun: () async {
           // Unsure the device can consume it.
@@ -943,8 +943,7 @@ class Transport extends EnhancedEventEmitter {
             throw ('cannot consume this Producer');
           }
 
-          HandlerReceiveResult receiveResult =
-              await _handler.receive(HandlerReceiveOptions(
+          final receiveResult = await _handler.receive(HandlerReceiveOptions(
             trackId: id,
             kind: kind,
             rtpParameters: rtpParameters,

--- a/lib/src/handlers/Native.dart
+++ b/lib/src/handlers/Native.dart
@@ -179,13 +179,14 @@ class Native extends HandlerInterface {
 
     _logger.debug('receive() [trackId:${options.trackId}, kind:${RTCRtpMediaTypeExtension.value(options.kind)}]');
 
-    String localId = options.trackId;
-    String mid = RTCRtpMediaTypeExtension.value(options.kind);
+
+    String mid =  options.rtpParameters.mid;
+    String localId = mid ?? options.trackId;
     String streamId = options.rtpParameters.rtcp.cname;
 
     _logger.debug(
 			'receive() | forcing a random remote streamId to avoid well known bug in native');
-    streamId += '-hack-${generateRandomNumber()}';
+    //streamId += '-hack-${generateRandomNumber()}';
 
     _remoteSdp.receive(
       mid: mid,

--- a/lib/src/handlers/sdp/MediaSection.dart
+++ b/lib/src/handlers/sdp/MediaSection.dart
@@ -1287,7 +1287,7 @@ class OfferMediaSection extends MediaSection {
               rate: codec.clockRate,
             );
 
-            if (codec.channels > 1) {
+            if (codec.channels != null && codec.channels > 1) {
               rtp.encoding = codec.channels;
             }
 


### PR DESCRIPTION
Small debugging fixes,

should help with debugging receiving.

Consumer audio is blocked out just to not flood the logs with audio/video receiving all at once.

`proprietaryConstraints` and `additionalSettings` are not actually needed judging by original typescript mediasoup client. But can be added back in if you feel the need to.
